### PR TITLE
Resize images before saving them

### DIFF
--- a/image_optimizer/fields.py
+++ b/image_optimizer/fields.py
@@ -24,6 +24,13 @@ class OptimizedImageField(ImageField):
 
     def __init__(self, optimized_image_output_size=None,
                  optimized_image_resize_method=None, *args, **kwargs):
+        """
+        Initialize OptimizedImageField instance.
+
+        set up the `optimized_image_output_size` and
+        `optimized_image_resize_method` arguments for the current
+        `OptimizedImageField` instance.
+        """
         # Set the optimized_image_output_size specified on your
         # OptimizedImageField model instances
         self.optimized_image_output_size = optimized_image_output_size

--- a/image_optimizer/fields.py
+++ b/image_optimizer/fields.py
@@ -27,6 +27,7 @@ class OptimizedImageField(ImageField):
         self.optimized_image_output_size = optimized_image_output_size
 
         super(OptimizedImageField, self).__init__(
+            optimized_image_output_size,
             *args,
             **kwargs
         )

--- a/image_optimizer/fields.py
+++ b/image_optimizer/fields.py
@@ -14,5 +14,20 @@ class OptimizedImageField(ImageField):
 
         if updating_image:
             from .utils import image_optimizer
-            data = image_optimizer(data)
+            data = image_optimizer(
+                data,
+                self.optimized_image_output_size
+            )
+
         super().save_form_data(instance, data)
+
+    def __init__(self, optimized_image_output_size=None, *args, **kwargs):
+        # Set the optimized_image_output_size specified on your model
+        # OptimizedImageField instances
+        self.optimized_image_output_size = optimized_image_output_size
+
+        super(OptimizedImageField, self).__init__(
+            optimized_image_output_size,
+            *args,
+            **kwargs
+        )

--- a/image_optimizer/fields.py
+++ b/image_optimizer/fields.py
@@ -16,14 +16,19 @@ class OptimizedImageField(ImageField):
             from .utils import image_optimizer
             data = image_optimizer(
                 data,
-                self.optimized_image_output_size
+                self.optimized_image_output_size,
+                self.optimized_image_resize_method
             )
 
         super().save_form_data(instance, data)
 
-    def __init__(self, optimized_image_output_size=None, *args, **kwargs):
-        # Set the optimized_image_output_size specified on your model
-        # OptimizedImageField instances
+    def __init__(self, optimized_image_output_size=None,
+                 optimized_image_resize_method=None, *args, **kwargs):
+        # Set the optimized_image_output_size specified on your
+        # OptimizedImageField model instances
         self.optimized_image_output_size = optimized_image_output_size
+        # Set the optimized_image_resize_method specified on your
+        # OptimizedImageField model instances
+        self.optimized_image_resize_method = optimized_image_resize_method
 
         super().__init__(**kwargs)

--- a/image_optimizer/fields.py
+++ b/image_optimizer/fields.py
@@ -32,3 +32,20 @@ class OptimizedImageField(ImageField):
         self.optimized_image_resize_method = optimized_image_resize_method
 
         super().__init__(**kwargs)
+
+    def deconstruct(self):
+        """
+        Deconstruct method.
+
+        deconstruct the field, allowing us to handle the field data, useful
+        in cases where you want to add optional arguments to your custom
+        field but you need to exclude them from migrations.
+        """
+        name, path, args, kwargs = super().deconstruct()
+        if kwargs.get('optimized_image_output_size') is not None:
+            del kwargs["optimized_image_output_size"]
+
+        if kwargs.get('optimized_image_resize_method') is not None:
+            del kwargs["optimized_image_resize_method"]
+
+        return name, path, args, kwargs

--- a/image_optimizer/fields.py
+++ b/image_optimizer/fields.py
@@ -27,7 +27,6 @@ class OptimizedImageField(ImageField):
         self.optimized_image_output_size = optimized_image_output_size
 
         super(OptimizedImageField, self).__init__(
-            optimized_image_output_size,
             *args,
             **kwargs
         )

--- a/image_optimizer/fields.py
+++ b/image_optimizer/fields.py
@@ -26,8 +26,4 @@ class OptimizedImageField(ImageField):
         # OptimizedImageField instances
         self.optimized_image_output_size = optimized_image_output_size
 
-        super(OptimizedImageField, self).__init__(
-            optimized_image_output_size,
-            *args,
-            **kwargs
-        )
+        super().__init__(**kwargs)

--- a/image_optimizer/settings.py
+++ b/image_optimizer/settings.py
@@ -3,5 +3,5 @@ from __future__ import unicode_literals
 
 from django.conf import settings
 
-OPTIMIZED_IMAGE_METHOD = getattr(settings, 'OPTIMIZED_IMAGE_METHOD', 'tinypng')
+OPTIMIZED_IMAGE_METHOD = getattr(settings, 'OPTIMIZED_IMAGE_METHOD', 'pillow')
 TINYPNG_KEY = getattr(settings, 'TINYPNG_KEY', None)

--- a/image_optimizer/utils.py
+++ b/image_optimizer/utils.py
@@ -25,9 +25,8 @@ def get_file_extension(file_name):
     return extension
 
 
-def image_optimizer(image_data, output_size, resize_method='thumbnail'):
+def image_optimizer(image_data, output_size=None, resize_method=None):
     """Optimize an image that has not been saved to a file."""
-
     if OPTIMIZED_IMAGE_METHOD == 'pillow':
         image = Image.open(image_data)
         bytes_io = BytesIO()
@@ -35,9 +34,14 @@ def image_optimizer(image_data, output_size, resize_method='thumbnail'):
         file_name = image_data.name
         extension = get_file_extension(file_name)
 
+        # If output_size is set, resize the image with the selected
+        # resize_method. 'thumbnail' is used by default
         if output_size is not None:
 
-            if resize_method is 'thumbnail':
+            if resize_method is None:
+                pass
+
+            elif resize_method is 'thumbnail':
                 image = resizeimage.resize_thumbnail(
                     image,
                     output_size,
@@ -53,7 +57,7 @@ def image_optimizer(image_data, output_size, resize_method='thumbnail'):
 
             else:
                 raise Exception(
-                    'optimized_image_resize_method misconfigured, it\'s value must be \'thumbnail\' or \'cover\''
+                    'optimized_image_resize_method misconfigured, it\'s value must be \'thumbnail\', \'cover\' or None'
                 )
 
             output_image = Image.new(
@@ -72,6 +76,7 @@ def image_optimizer(image_data, output_size, resize_method='thumbnail'):
                 output_image_center
             )
 
+        # If output_size is None the output_image would be the same as source
         else:
             output_image = image
 

--- a/image_optimizer/utils.py
+++ b/image_optimizer/utils.py
@@ -3,26 +3,78 @@ from __future__ import unicode_literals
 
 from io import BytesIO
 from PIL import Image
+from resizeimage import resizeimage
 
 import tinify
 import requests
 
 from .settings import (OPTIMIZED_IMAGE_METHOD, TINYPNG_KEY)
 
+BACKGROUND_TRANSPARENT = (255, 255, 255, 0)
 
-def image_optimizer(image_data):
+
+def get_file_extension(file_name):
+    extension = None
+
+    # Get image file extension
+    if file_name.split('.')[-1].lower() != 'jpg':
+        extension = file_name.split('.')[-1].upper()
+    else:
+        extension = 'JPEG'
+
+    return extension
+
+
+def image_optimizer(image_data, output_size):
     """Optimize an image that has not been saved to a file."""
+
     if OPTIMIZED_IMAGE_METHOD == 'pillow':
         image = Image.open(image_data)
         bytes_io = BytesIO()
-        if image_data.name.split('.')[-1].lower() != 'jpg':
-            extension = image_data.name.split('.')[-1].upper()
+
+        file_name = image_data.name
+        extension = get_file_extension(file_name)
+
+        if output_size is not None:
+            image = resizeimage.resize_thumbnail(
+                image,
+                output_size,
+                resample=Image.LANCZOS
+            )
+
+            output_image = Image.new(
+                'RGBA',
+                output_size,
+                BACKGROUND_TRANSPARENT
+            )
+
+            output_image_center = (
+                int((output_size[0] - image.size[0]) / 2),
+                int((output_size[1] - image.size[1]) / 2)
+            )
+
+            output_image.paste(
+                image,
+                output_image_center
+            )
+
         else:
-            extension = 'JPEG'
-        image.save(bytes_io, format=extension, optimize=True)
+            output_image = image
+
+        # If the file extension is JPEG, convert the output_image to RGB
+        if extension == 'JPEG':
+            output_image = output_image.convert("RGB")
+
+        output_image.save(
+            bytes_io,
+            format=extension,
+            optimize=True
+        )
+
         image_data.seek(0)
         image_data.file.write(bytes_io.getvalue())
         image_data.file.truncate()
+
     elif OPTIMIZED_IMAGE_METHOD == 'tinypng':
         # disable warning info
         requests.packages.urllib3.disable_warnings()

--- a/image_optimizer/utils.py
+++ b/image_optimizer/utils.py
@@ -25,7 +25,7 @@ def get_file_extension(file_name):
     return extension
 
 
-def image_optimizer(image_data, output_size):
+def image_optimizer(image_data, output_size, resize_method='thumbnail'):
     """Optimize an image that has not been saved to a file."""
 
     if OPTIMIZED_IMAGE_METHOD == 'pillow':
@@ -36,11 +36,25 @@ def image_optimizer(image_data, output_size):
         extension = get_file_extension(file_name)
 
         if output_size is not None:
-            image = resizeimage.resize_thumbnail(
-                image,
-                output_size,
-                resample=Image.LANCZOS
-            )
+
+            if resize_method is 'thumbnail':
+                image = resizeimage.resize_thumbnail(
+                    image,
+                    output_size,
+                    resample=Image.LANCZOS
+                )
+
+            elif resize_method is 'cover':
+                image = resizeimage.resize_cover(
+                    image,
+                    output_size,
+                    validate=False
+                )
+
+            else:
+                raise Exception(
+                    'optimized_image_resize_method misconfigured, it\'s value must be \'thumbnail\' or \'cover\''
+                )
 
             output_image = Image.new(
                 'RGBA',

--- a/image_optimizer_demo/app_demo/admin.py
+++ b/image_optimizer_demo/app_demo/admin.py
@@ -2,7 +2,10 @@
 from __future__ import unicode_literals
 
 from django.contrib import admin
-from app_demo.models import Post
+from app_demo.models import (
+    Post,
+    Collaborator,
+)
 
 
 class PostAdmin(admin.ModelAdmin):
@@ -10,4 +13,10 @@ class PostAdmin(admin.ModelAdmin):
     list_filter = ['created']
 
 
+class CollaboratorAdmin(admin.ModelAdmin):
+    list_display = ['name', 'created']
+    list_filter = ['created']
+
+
 admin.site.register(Post, PostAdmin)
+admin.site.register(Collaborator, CollaboratorAdmin)

--- a/image_optimizer_demo/app_demo/models.py
+++ b/image_optimizer_demo/app_demo/models.py
@@ -31,3 +31,36 @@ class Post(models.Model):
 
     class Meta:
         ordering = ['-created']
+
+
+class Collaborator(models.Model):
+    """
+    Collaborator model.
+
+    This model represents a Blog Collaborator(a.k.a. Writter) with a few
+    fields including a `profile_image` field which is an OptimizedImageField
+    instance with `optimized_image_output_size` and
+    `optimized_image_resize_method` arguments set.
+
+    This means that our Collaborator profile_image would be a resized
+    version of the source image, meant to keep a given screen resolution,
+    in this case (400, 300) pixels.
+    """
+
+    name = models.CharField(
+        max_length=100
+    )
+    profile_image = OptimizedImageField(
+        upload_to='uploads/collaborators/%Y/%m/%d',
+        optimized_image_output_size=(400, 300),
+        optimized_image_resize_method='cover'  # 'thumbnail' or 'cover'
+    )
+    created = models.DateTimeField(
+        auto_now_add=True
+    )
+
+    def __str__(self):
+        return self.name
+
+    class Meta:
+        ordering = ['-created']

--- a/image_optimizer_demo/app_demo/models.py
+++ b/image_optimizer_demo/app_demo/models.py
@@ -20,7 +20,7 @@ class Post(models.Model):
         max_length=100
     )
     photo = OptimizedImageField(
-        upload_to='uploads/%Y/%m/%d'
+        upload_to='uploads/posts/%Y/%m/%d'
     )
     created = models.DateTimeField(
         auto_now_add=True

--- a/image_optimizer_demo/app_demo/models.py
+++ b/image_optimizer_demo/app_demo/models.py
@@ -1,3 +1,4 @@
+"""app_demo models."""
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals
 
@@ -6,9 +7,15 @@ from image_optimizer.fields import OptimizedImageField
 
 
 class Post(models.Model):
-    title = models.CharField(max_length=100)
-    photo = OptimizedImageField(upload_to='uploads/%Y/%m/%d')
-    created = models.DateTimeField(auto_now_add=True)
+    title = models.CharField(
+        max_length=100
+    )
+    photo = OptimizedImageField(
+        upload_to='uploads/%Y/%m/%d'
+    )
+    created = models.DateTimeField(
+        auto_now_add=True
+    )
 
     def __str__(self):
         return self.title

--- a/image_optimizer_demo/app_demo/models.py
+++ b/image_optimizer_demo/app_demo/models.py
@@ -7,6 +7,15 @@ from image_optimizer.fields import OptimizedImageField
 
 
 class Post(models.Model):
+    """
+    Post model.
+
+    This model represents a Blog Post with a few fields including a `photo`
+    field which is an OptimizedImageField instance without any optional
+    argument. This means that out Post photo would keep source image original
+    size.
+    """
+
     title = models.CharField(
         max_length=100
     )

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,8 @@ install_requires = [
     'Django',
     'Pillow',
     'requests',
-    'tinify'
+    'tinify',
+    'python-resize-image'
 ]
 
 setup(


### PR DESCRIPTION
Hello there

I implemented a new optional argument for OptimizedImageField to allow us to resize the images automatically before saving them.

Example
``` python
image = OptimizedImageField(
    blank=True,
    null=True,
    optimized_image_output_size=(300, 300)
)
```

This will produce an output_image with a size of 300px by 300 px, but you can set it to None(default and backwards compatible) or other size you want to convert your app images to.

I'll add other arguments to improve this package soon.